### PR TITLE
schistocerca_compatible

### DIFF
--- a/rnannot/RNAseq_annotate.py
+++ b/rnannot/RNAseq_annotate.py
@@ -516,6 +516,7 @@ if __name__ == '__main__':
     bam_dir = path.join(args.outdir, args.name, 'output.bam')
     output_dir = path.join(args.outdir, args.name, 'output.sorted.bam')
     subprocess.run(['samtools', 'sort', '-@', args.threads_num, bam_dir, '-o', output_dir])
+    subprocess.run(['samtools', 'index', '-c@', args.threads_num, output_dir]) #Creating a .csi index immediately so that bam_to_bigwig.py doesn't try to make a .bai index
     # converting dowsampled bam to bigwig (includes indexing bam file)
     print('Generating bigwig file from bam file...')
     bam_dir = path.join(args.outdir, args.name, 'output.sorted.bam')
@@ -530,7 +531,7 @@ if __name__ == '__main__':
     if args.Run_prefix:
         new_name = runs[0]
     os.rename(path.join(args.outdir, args.name, 'output.sorted.bam'), path.join(args.outdir, args.name, new_name + '.bam'))
-    os.rename(path.join(args.outdir, args.name, 'output.sorted.bam.bai'), path.join(args.outdir, args.name, new_name + '.bam.bai'))
+    os.rename(path.join(args.outdir, args.name, 'output.sorted.bam.csi'), path.join(args.outdir, args.name, new_name + '.bam.csi')) #Changed from .bai to .csi
     os.rename(path.join(args.outdir, args.name, 'output.bigwig'), path.join(args.outdir, args.name, new_name + '.bigwig'))
     # generate bed file
     subprocess.run([get_regtools_path(), 'junctions', 'extract', '-m', '20', '-s', '0', '-o', path.join(args.outdir, args.name, new_name + '.bed'), path.join(args.outdir, args.name, new_name + '.bam')])

--- a/rnannot/download_sra_metadata.py
+++ b/rnannot/download_sra_metadata.py
@@ -14,7 +14,7 @@ proc_esearch = subprocess.Popen(['esearch', '-db', 'taxonomy', '-query' , tax_id
 time.sleep(0.7)
 proc_elink = subprocess.Popen(['elink', '-target', 'sra'], stdin=proc_esearch.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
-proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT ^454+[A-Z ]$[platform] NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
+proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
 proc_efetch = subprocess.Popen(['efetch', '-format', 'runinfo', '-mode', 'xml'], stdin=proc_efilter.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)

--- a/rnannot/download_sra_metadata.py
+++ b/rnannot/download_sra_metadata.py
@@ -14,7 +14,7 @@ proc_esearch = subprocess.Popen(['esearch', '-db', 'taxonomy', '-query' , tax_id
 time.sleep(0.7)
 proc_elink = subprocess.Popen(['elink', '-target', 'sra'], stdin=proc_esearch.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
-proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT(SINGLE[LibraryLayout] AND ^454+[A-Z ]$[platform]) NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
+proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT ^454+[A-Z ]$[platform] NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
 proc_efetch = subprocess.Popen(['efetch', '-format', 'runinfo', '-mode', 'xml'], stdin=proc_efilter.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)

--- a/rnannot/download_sra_metadata.py
+++ b/rnannot/download_sra_metadata.py
@@ -14,7 +14,7 @@ proc_esearch = subprocess.Popen(['esearch', '-db', 'taxonomy', '-query' , tax_id
 time.sleep(0.7)
 proc_elink = subprocess.Popen(['elink', '-target', 'sra'], stdin=proc_esearch.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
-proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
+proc_efilter = subprocess.Popen(['efilter', '-query', 'rna seq[stra] AND Transcriptomic[src] NOT(SINGLE[LibraryLayout] AND ^454+[A-Z ]$[platform]) NOT PACBIO_SMRT[platform]'], stdin=proc_elink.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)
 proc_efetch = subprocess.Popen(['efetch', '-format', 'runinfo', '-mode', 'xml'], stdin=proc_efilter.stdout, stdout=subprocess.PIPE)
 time.sleep(0.7)


### PR DESCRIPTION
These changes are meant to update the pipeline to be compatible with large genomes such as those of the _Schistocerca_ genus. Mainly this meant updating the pipeline to use .csi indeces for .bam files rather than the older .bai indeces. This allows the use of .BAM files without the size constraint of the old .bai indeces.
Additionally, a small change was made to download_sra_metadata.py, avoiding an error caused by the previous query syntax which searches for a column that doesn't exist in the _Schistocerca_ sra files.

Be sure to also update your bam_to_bigwig.py script, those changes will be pushed separately onto that repository.